### PR TITLE
Changed use w = world to use world as w

### DIFF
--- a/src/examples/asteroids/sys/aster.rs
+++ b/src/examples/asteroids/sys/aster.rs
@@ -1,6 +1,6 @@
 use std::rand::{Rng, StdRng};
 use cgmath::{Angle, Deg, Rad, ToRad, Point, Point2, Vector, sin, cos};
-use w = world;
+use world as w;
 
 static KINDS: uint = 2;
 

--- a/src/examples/asteroids/sys/bullet.rs
+++ b/src/examples/asteroids/sys/bullet.rs
@@ -1,6 +1,6 @@
 use cgmath::{Angle, Rad, Point, Vector};
 use ces;
-use w = world;
+use world as w;
 
 pub enum Event {
     EvShoot(bool),

--- a/src/examples/asteroids/sys/control.rs
+++ b/src/examples/asteroids/sys/control.rs
@@ -1,5 +1,5 @@
 use cgmath::{Angle, Rad, Point, Vector};
-use w = world;
+use world as w;
 
 pub enum Event {
     EvThrust(f32),

--- a/src/examples/asteroids/sys/draw.rs
+++ b/src/examples/asteroids/sys/draw.rs
@@ -1,6 +1,6 @@
 use gfx;
 use ces;
-use w = world;
+use world as w;
 
 pub struct System {
     extents: [f32, ..2],

--- a/src/examples/asteroids/sys/inertia.rs
+++ b/src/examples/asteroids/sys/inertia.rs
@@ -1,5 +1,5 @@
 use cgmath::{Angle, Point, Vector};
-use w = world;
+use world as w;
 
 pub struct System;
 

--- a/src/examples/asteroids/sys/physics.rs
+++ b/src/examples/asteroids/sys/physics.rs
@@ -1,5 +1,5 @@
 use cgmath::{Point, EuclideanVector};
-use w = world;
+use world as w;
 
 pub struct System;
 


### PR DESCRIPTION
For asteroids example in response to breaking change of use syntax.
